### PR TITLE
docs: clarify abort signal requirement in withRetry

### DIFF
--- a/src/utils/withRetry/withRetry.ts
+++ b/src/utils/withRetry/withRetry.ts
@@ -19,7 +19,7 @@ export function withRetry<T>(
         }
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
             try {
-                // assuming action is will be aborted if signal is aborted
+                // the provided action must listen to the AbortSignal and stop if it is triggered
                 return await action();
             } catch (error) {
                 if (isAbortError(error)) {


### PR DESCRIPTION
## Summary
- clarify that the retried action must honour AbortSignal

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7453f89c832c96d2a70a32f04dca