### PR TITLE
test: assert custom retry rejection

### DIFF
--- a/src/utils/withRetry/withRetry.spec.ts
+++ b/src/utils/withRetry/withRetry.spec.ts
@@ -114,16 +114,13 @@ describe("withRetry", () => {
 
         const retryableAction = withRetry(mockAction, { maxRetries: 7, delayStep: 50 });
 
-        const resultPromise = retryableAction().catch(
-            (error) => {
-                expect(error).toEqual(error);
-            },
-        );
+        const resultPromise = retryableAction();
+        const expectation = expect(resultPromise).rejects.toBe(error);
 
         await jest.advanceTimersByTimeAsync(100500);
 
         expect(mockAction).toHaveBeenCalledTimes(7);
-        await resultPromise;
+        await expectation;
     });
 
     it("should use growing delay between retries", async () => {


### PR DESCRIPTION
## Summary
- verify `withRetry` rejects with the provided error when retries exceed custom count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fecac2a78832cb212aa6524f6e706